### PR TITLE
feat: Add JS RPC Support for getYDoc and updateYDoc

### DIFF
--- a/.changeset/healthy-penguins-sing.md
+++ b/.changeset/healthy-penguins-sing.md
@@ -1,5 +1,34 @@
 ---
-"y-durableobjects": minor
+"y-durableobjects": major
 ---
 
-add ydoc handle interface for js rpc
+Add JS RPC Support for getYDoc and updateYDoc
+
+1. **Major Features**:
+
+   - **JS RPC APIs `getYDoc` and `updateYDoc`**:
+     - Implemented new JS RPC APIs to fetch (`getYDoc`) and update (`updateYDoc`) YDocs within Durable Objects.
+     - Allows manipulating YDocs from sources other than WebSocket, enhancing flexibility and control.
+
+2. **Hono Integration**:
+
+   - Added examples for integrating `y-durableobjects` with Hono, using both shorthand and detailed methods.
+   - Demonstrated how to handle WebSocket connections via fetch due to the current limitations of JS RPC (see [Cloudflare issue](https://github.com/cloudflare/workerd/issues/2319)).
+
+3. **Extending with JS RPC**:
+
+   - Explained how to extend `y-durableobjects` for advanced operations, including accessing and manipulating protected fields:
+     - `app`: The Hono app instance used to handle requests.
+     - `doc`: An instance of `WSSharedDoc` managing the YDoc state.
+     - `storage`: A `YTransactionStorageImpl` instance for storing and retrieving YDoc updates.
+     - `sessions`: A map to manage active WebSocket sessions.
+     - `awarenessClients`: A set to track client awareness states.
+   - Provided a minimal example of creating a custom Durable Object by extending `YDurableObjects`.
+
+4. **Client-side Typed Fetch with Hono RPC**:
+
+   - Included a guide for creating a typed client using `hc` from `hono/client` to facilitate Hono RPC on the client side.
+
+5. **Documentation Updates**:
+   - Updated the README with detailed examples and explanations for the new features and integrations.
+   - Ensured clarity and ease of understanding for developers looking to utilize the new functionalities.

--- a/.changeset/healthy-penguins-sing.md
+++ b/.changeset/healthy-penguins-sing.md
@@ -1,0 +1,5 @@
+---
+"y-durableobjects": minor
+---
+
+add ydoc handle interface for js rpc

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -13,4 +13,12 @@ module.exports = {
       },
     ],
   },
+  overrides: [
+    {
+      files: ["src/e2e/**/*"],
+      rules: {
+        "import/no-extraneous-dependencies": "off",
+      },
+    },
+  ],
 };

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -6,5 +6,11 @@ module.exports = {
   },
   rules: {
     "no-restricted-imports": "off",
+    "import/no-unresolved": [
+      "error",
+      {
+        ignore: ["^cloudflare:.*$"],
+      },
+    ],
   },
 };

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Yjs on Cloudflare Workers with Durable Objects Demo Movie](https://i.gyazo.com/e94637740dbb11fc5107b0cd0850326d.gif)](https://gyazo.com/e94637740dbb11fc5107b0cd0850326d)
 
-The `y-durableobjects` library is designed to facilitate real-time collaboration in Cloudflare Workers environment using Yjs and Durable Objects. It provides a straightforward way to integrate Yjs for decentralized, scalable real-time editing features.
+The `y-durableobjects` library is designed to facilitate real-time collaboration in the Cloudflare Workers environment using Yjs and Durable Objects. It provides a straightforward way to integrate Yjs for decentralized, scalable real-time editing features.
 
 ## Requirements
 
@@ -28,23 +28,19 @@ or pnpm:
 pnpm add y-durableobjects hono
 ```
 
-Below is an updated section for your README, including the recommended `wrangler.toml` configuration for Durable Objects, followed by the new section providing guidance on configuring Durable Objects:
+### Configuration for Durable Objects
 
----
+To properly utilize Durable Objects, you need to configure bindings in your `wrangler.toml` file. This involves specifying the name of the Durable Object binding and the class name that represents your Durable Object. For detailed instructions on how to set up your `wrangler.toml` for Durable Objects, including setting up environment variables and additional resources, refer to [Cloudflare's Durable Objects documentation](https://developers.cloudflare.com/durable-objects/get-started/#5-configure-durable-object-bindings).
 
-## Configuring Durable Objects
-
-To use Durable Objects with `y-durableobjects`, include the following configuration in your `wrangler.toml` file. This setup is essential for defining the Durable Object bindings that your Cloudflare Worker will use.
+This configuration ensures that your Cloudflare Worker can correctly instantiate and interact with Durable Objects, allowing `y-durableobjects` to manage real-time collaboration sessions.
 
 ```toml
 name = "your-worker-name"
-main = "index.js"
-compatibility_date = "2021-10-01"
+main = "src/index.ts"
+compatibility_date = "2024-04-05"
 
 account_id = "your-account-id"
 workers_dev = true
-route = ""
-zone_id = ""
 
 # Durable Objects binding
 [durable_objects]
@@ -52,20 +48,11 @@ bindings = [
   { name = "Y_DURABLE_OBJECTS", class_name = "YDurableObjects" }
 ]
 
-# Add your KV Namespaces and other bindings here
-# [kv_namespaces]
-# ...
-
-# Your environment variables
-# [vars]
-# ...
+# Durable Objects migrations
+[[migrations]]
+tag = "v1"
+new_classes = ["YDurableObjects"]
 ```
-
-### Configuration for Durable Objects
-
-To properly utilize Durable Objects, you need to configure bindings in your `wrangler.toml` file. This involves specifying the name of the Durable Object binding and the class name that represents your Durable Object. For detailed instructions on how to set up your `wrangler.toml` for Durable Objects, including setting up environment variables and additional resources, refer to [Cloudflare's Durable Objects documentation](https://developers.cloudflare.com/durable-objects/get-started/#5-configure-durable-object-bindings).
-
-This configuration ensures that your Cloudflare Worker can correctly instantiate and interact with Durable Objects, allowing `y-durableobjects` to manage real-time collaboration sessions.
 
 ## Extending Hono with Bindings
 
@@ -91,62 +78,9 @@ This allows you to use `Y_DURABLE_OBJECTS` directly in your Hono application wit
 
 ```typescript
 import { Hono } from "hono";
-import { cors } from "hono/cors";
 import { YDurableObjects, yRoute } from "y-durableobjects";
 
 const app = new Hono();
-app.use("*", cors());
-
-const route = app.route(
-  "/editor",
-  yRoute((env) => env.Y_DURABLE_OBJECTS),
-);
-
-export default route;
-export { YDurableObjects };
-```
-
-### Without the shorthand
-
-```typescript
-import { Hono } from "hono";
-import { cors } from "hono/cors";
-import { YDurableObjects } from "y-durableobjects";
-
-const app = new Hono();
-app.use("*", cors());
-app.get("/editor/:id", async (c) => {
-  const id = c.env.Y_DURABLE_OBJECTS.idFromName(c.req.param("id"));
-  const obj = c.env.Y_DURABLE_OBJECTS.get(id);
-
-  // get websocket connection
-  const url = new URL("/", c.req.url);
-  const res = await obj.fetch(url.href, {
-    headers: c.req.raw.headers,
-  });
-  if (res.webSocket === null) return c.body(null, 500);
-
-  return new Response(null, { webSocket: res.webSocket, status: res.status });
-});
-
-export default app;
-export { YDurableObjects };
-```
-
-### Hono RPC support
-
-- Utilizes Hono's WebSocket Helper, making the `$ws` method available in `hono/client` for WebSocket communications.
-  - For more information on server and client setup, see the [Hono WebSocket Helper documentation](https://hono.dev/helpers/websocket#server-and-client).
-
-#### Server Implementation
-
-```typescript
-import { Hono } from "hono";
-import { cors } from "hono/cors";
-import { YDurableObjects, yRoute } from "y-durableobjects";
-
-const app = new Hono();
-app.use("*", cors());
 
 const route = app.route(
   "/editor",
@@ -158,7 +92,186 @@ export type AppType = typeof route;
 export { YDurableObjects };
 ```
 
+### Without the shorthand
+
+The following example demonstrates how to integrate Hono RPC with `y-durableobjects`. Note that WebSocket connections must be handled via fetch due to the current limitations of JS RPC (see [Cloudflare issue](https://github.com/cloudflare/workerd/issues/2319)):
+
+```typescript
+import { Hono } from "hono";
+import { YDurableObjects, type YDurableObjectsAppType } from "y-durableobjects";
+import { upgrade } from "y-durableobjects/helpers/upgrade";
+
+const app = new Hono();
+app.get("/editor/:id", upgrade(), async (c) => {
+  const id = c.env.Y_DURABLE_OBJECTS.idFromName(c.req.param("id"));
+  const stub = c.env.Y_DURABLE_OBJECTS.get(id);
+
+  const url = new URL("/", c.req.url);
+  const client = hc<YDurableObjectsAppType>(url, {
+    fetch: stub.fetch.bind(stub),
+  });
+
+  const res = await client.rooms[":id"].$get(
+    { param: { id: c.req.param("id") } },
+    { init: { headers: c.req.raw.headers } },
+  );
+
+  return new Response(null, {
+    webSocket: res.webSocket,
+    status: res.status,
+    statusText: res.statusText,
+  });
+});
+
+export default app;
+export type AppType = typeof app;
+export { YDurableObjects };
+```
+
+### JS RPC support
+
+`y-durableobjects` supports JS RPC for fetching and updating YDocs. Below are examples of how to use the `getYDoc` and `updateYDoc` interfaces.
+
+#### getYDoc
+
+This API fetches the state of the YDoc within a Durable Object.
+
+Example usage in Hono:
+
+```typescript
+import { Hono } from "hono";
+import { YDurableObjects } from "y-durableobjects";
+import { fromUint8Array } from "js-base64";
+
+const app = new Hono();
+
+app.get("/rooms/:id/state", async (c) => {
+  const roomId = c.req.param("id");
+  const id = c.env.Y_DURABLE_OBJECTS.idFromName(roomId);
+  const stub = c.env.Y_DURABLE_OBJECTS.get(id);
+
+  const doc = await stub.getYDoc();
+  const base64 = fromUint8Array(doc);
+
+  return c.json({ doc: base64 }, 200);
+});
+
+export default app;
+export { YDurableObjects };
+```
+
+#### updateYDoc
+
+This API updates the state of the YDoc within a Durable Object.
+
+Example usage in Hono:
+
+```typescript
+import { Hono } from "hono";
+import { YDurableObjects } from "y-durableobjects";
+
+const app = new Hono();
+
+app.post("/rooms/:id/update", async (c) => {
+  const roomId = c.req.param("id");
+  const id = c.env.Y_DURABLE_OBJECTS.idFromName(roomId);
+  const stub = c.env.Y_DURABLE_OBJECTS.get(id);
+
+  const buffer = await c.req.arrayBuffer();
+  const update = new Uint8Array(buffer);
+
+  await stub.updateYDoc(update);
+
+  return c.json(null, 200);
+});
+
+export default app;
+export { YDurableObjects };
+```
+
+### Extending with JS RPC
+
+By supporting JS RPC, `y-durableobjects` allows for advanced operations through extensions. You can manipulate the protected fields for custom functionality:
+
+Example:
+
+```typescript
+import { applyUpdate, encodeStateAsUpdate } from "yjs";
+import { YDurableObjects } from "y-durableobjects";
+
+export class CustomDurableObject extends YDurableObjects {
+  async customMethod() {
+    // Access and manipulate the YDoc state
+    const update = new Uint8Array([
+      /* some update data */
+    ]);
+    this.doc.update(update);
+    await this.cleanup();
+  }
+}
+```
+
+### Hono RPC support for ClientSide
+
+- Utilizes Hono's WebSocket Helper, making the `$ws` method available in `hono/client` for WebSocket communications.
+  - For more information on server and client setup, see the [Hono WebSocket Helper documentation](https://hono.dev/helpers/websocket#server-and-client).
+
+#### Server Implementation
+
+##### Using shorthand
+
+```typescript
+import { Hono } from "hono";
+import { YDurableObjects, yRoute } from "y-durableobjects";
+
+const app = new Hono();
+const route = app.route(
+  "/editor",
+  yRoute((env) => env.Y_DURABLE_OBJECTS),
+);
+
+export default route;
+export type AppType = typeof route;
+export { YDurableObjects };
+```
+
+##### Without shorthand
+
+```typescript
+import { Hono } from "hono";
+import { YDurableObjects, YDurableObjectsAppType } from "y-durableobjects";
+import { upgrade } from "y-durableobjects/helpers/upgrade";
+
+const app = new Hono();
+app.get("/editor/:id", upgrade(), async (c) => {
+  const id = c.env.Y_DURABLE_OBJECTS.idFromName(c.req.param("id"));
+  const stub = c.env.Y_DURABLE_OBJECTS.get(id);
+
+  const url = new URL("/", c.req.url);
+  const client = hc<YDurableObjectsAppType>(url, {
+    fetch: stub.fetch.bind(stub),
+  });
+
+  const res = await client.rooms[":id"].$get(
+    { param: { id: c.req.param("id") } },
+    { init: { headers: c.req.raw.headers } },
+  );
+
+  return new Response(null, {
+    webSocket: res.webSocket,
+    status: res.status,
+    statusText: res.statusText,
+  });
+});
+
+export default app;
+export type AppType = typeof app;
+export { YDurableObjects };
+```
+
 #### Client Implementation
+
+To utilize Hono RPC on the client side, you can create a typed client using `hc` from `hono/client`:
 
 ```typescript
 import { hc } from "hono/client";

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "yjs": "^13.6.18"
   },
   "peerDependencies": {
-    "@cloudflare/workers-types": ">=4.20240208.0",
+    "@cloudflare/workers-types": ">=4.20240405.0",
     "hono": ">=4.3"
   },
   "packageManager": "pnpm@9.4.0"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,23 @@
         "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"
       }
+    },
+    "./helpers/upgrade": {
+      "import": {
+        "types": "./dist/helpers/upgrade.d.ts",
+        "default": "./dist/helpers/upgrade.js"
+      },
+      "require": {
+        "types": "./dist/helpers/upgrade.d.cts",
+        "default": "./dist/helpers/upgrade.cjs"
+      }
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "helpers": [
+        "./dist/helpers"
+      ]
     }
   },
   "scripts": {
@@ -62,7 +79,8 @@
     "@cloudflare/workers-types": "^4.20240729.0",
     "@naporin0624/eslint-config": "^0.14.0",
     "eslint": "^8.56.0",
-    "hono": "^4.4.10",
+    "hono": "^4.5.3",
+    "js-base64": "^3.7.7",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.2.5",
     "publint": "^0.2.7",
@@ -72,7 +90,6 @@
     "wrangler": "^3.62.0"
   },
   "dependencies": {
-    "js-base64": "^3.7.7",
     "lib0": "^0.2.94",
     "y-protocols": "^1.0.6",
     "yjs": "^13.6.18"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   ],
   "devDependencies": {
     "@changesets/cli": "^2.27.7",
-    "@cloudflare/vitest-pool-workers": "^0.4.7",
+    "@cloudflare/vitest-pool-workers": "^0.4.17",
     "@cloudflare/workers-types": "^4.20240729.0",
     "@naporin0624/eslint-config": "^0.14.0",
     "eslint": "^8.56.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.27.7",
     "@cloudflare/vitest-pool-workers": "^0.4.7",
-    "@cloudflare/workers-types": "^4.20240620.0",
+    "@cloudflare/workers-types": "^4.20240729.0",
     "@naporin0624/eslint-config": "^0.14.0",
     "eslint": "^8.56.0",
     "hono": "^4.4.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      js-base64:
-        specifier: ^3.7.7
-        version: 3.7.7
       lib0:
         specifier: ^0.2.94
         version: 0.2.94
@@ -37,8 +34,11 @@ importers:
         specifier: ^8.56.0
         version: 8.56.0
       hono:
-        specifier: ^4.4.10
-        version: 4.4.10
+        specifier: ^4.5.3
+        version: 4.5.3
+      js-base64:
+        specifier: ^3.7.7
+        version: 3.7.7
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -1763,8 +1763,8 @@ packages:
     resolution: {integrity: sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==}
     engines: {node: '>= 0.4'}
 
-  hono@4.4.10:
-    resolution: {integrity: sha512-z6918u9rXRU5CCisMHd2uUVoQXcNyUrUMmYY7VH10v4HJG7+hqgMK/G8YNTd13C6s4rBfzF09iz8VpOip9qG3A==}
+  hono@4.5.3:
+    resolution: {integrity: sha512-r26WwwbKD3BAYdfB294knNnegNda7VfV1tVn66D9Kvl9WQTdrR+5eKdoeaQNHQcC3Gr0KBikzAtjd6VsRGVSaw==}
     engines: {node: '>=16.0.0'}
 
   hosted-git-info@2.8.9:
@@ -4998,7 +4998,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.4.10: {}
+  hono@4.5.3: {}
 
   hosted-git-info@2.8.9: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         specifier: ^2.27.7
         version: 2.27.7
       '@cloudflare/vitest-pool-workers':
-        specifier: ^0.4.7
-        version: 0.4.7(@cloudflare/workers-types@4.20240729.0)(@vitest/runner@1.5.0)(@vitest/snapshot@1.5.0)(vitest@1.5.0(@types/node@20.11.19))
+        specifier: ^0.4.17
+        version: 0.4.17(@cloudflare/workers-types@4.20240729.0)(@vitest/runner@1.5.0)(@vitest/snapshot@1.5.0)(vitest@1.5.0(@types/node@20.11.19))
       '@cloudflare/workers-types':
         specifier: ^4.20240729.0
         version: 4.20240729.0
@@ -142,8 +142,8 @@ packages:
     resolution: {integrity: sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==}
     engines: {node: '>=16.13'}
 
-  '@cloudflare/vitest-pool-workers@0.4.7':
-    resolution: {integrity: sha512-fX/qCPsQgi4w2xXpuCtz8LjvcANVC6KYpPDFO6UyhJ4q5F9VhN14CNesS8S8VWARzt8Q5rfVg9JlBysR3/8YQg==}
+  '@cloudflare/vitest-pool-workers@0.4.17':
+    resolution: {integrity: sha512-ddSKdWvYCdQ8p01NF9iIjOMDQVqexWcSFG38EWhSJeNuPiiYE0/fjV2pngjtrkRWk47CDpHg166W0XblPxPfXw==}
     peerDependencies:
       '@vitest/runner': 1.3.x - 1.5.x
       '@vitest/snapshot': 1.3.x - 1.5.x
@@ -155,8 +155,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@cloudflare/workerd-darwin-64@1.20240725.0':
+    resolution: {integrity: sha512-KpE7eycdZ9ON+tKBuTyqZh8SdFWHGrh2Ru9LcbpeFwb7O9gDQv9ceSdoV/T598qlT0a0yVKM62R6xa5ec0UOWA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
   '@cloudflare/workerd-darwin-arm64@1.20240620.1':
     resolution: {integrity: sha512-3rdND+EHpmCrwYX6hvxIBSBJ0f40tRNxond1Vfw7GiR1MJVi3gragiBx75UDFHCxfRw3J0GZ1qVlkRce2/Xbsg==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20240725.0':
+    resolution: {integrity: sha512-/UQlI04FdXLpPlDzzsWGz8TuKrMZKLowTo+8PkxgEiWIaBhE4DIDM5bwj3jM4Bs8yOLiL2ovQNpld5CnAKqA8g==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -167,14 +179,32 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@cloudflare/workerd-linux-64@1.20240725.0':
+    resolution: {integrity: sha512-Z5t12qYLvHz0b3ZRBBm2HQ93RiHrAnjFfdhtjMcgJypAGkiWpOCEn2xar/WqDhMfqnk0sa8aYiYAbMAlP1WN6w==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
   '@cloudflare/workerd-linux-arm64@1.20240620.1':
     resolution: {integrity: sha512-TThvkwNxaZFKhHZnNjOGqIYCOk05DDWgO+wYMuXg15ymN/KZPnCicRAkuyqiM+R1Fgc4kwe/pehjP8pbmcf6sg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
+  '@cloudflare/workerd-linux-arm64@1.20240725.0':
+    resolution: {integrity: sha512-j9gYXLOwOyNehLMzP7KxQ+Y6/nxcL9i6LTDJC6RChoaxLRbm0Y/9Otu+hfyzeNeRpt31ip6vqXZ1QQk6ygzI8A==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
   '@cloudflare/workerd-windows-64@1.20240620.1':
     resolution: {integrity: sha512-Y/BA9Yj0r7Al1HK3nDHcfISgFllw6NR3XMMPChev57vrVT9C9D4erBL3sUBfofHU+2U9L+ShLsl6obBpe3vvUw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workerd-windows-64@1.20240725.0':
+    resolution: {integrity: sha512-fkrJLWNN6rrPjZ0eKJx328NVMo4BsainKxAfqaPMEd6uRwjOM8uN8V4sSLsXXP8GQMAx6hAG2hU86givS4GItg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -2111,6 +2141,11 @@ packages:
     engines: {node: '>=16.13'}
     hasBin: true
 
+  miniflare@3.20240725.0:
+    resolution: {integrity: sha512-n9NTLI8J9Xt0Cls6dRpqoIPkVFnxD9gMnU/qDkDX9diKfN16HyxpAdA5mto/hKuRpjW19TxnTMcxBo90vZXemw==}
+    engines: {node: '>=16.13'}
+    hasBin: true
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -2998,12 +3033,27 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  workerd@1.20240725.0:
+    resolution: {integrity: sha512-VZwgejRcHsQ9FEPtc7v25ebINLAR+stL3q1hC1xByE+quskdoWpTXHkZwZ3IdSgvm9vPVbCbJw9p5mGnDByW2A==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   wrangler@3.62.0:
     resolution: {integrity: sha512-TM1Bd8+GzxFw/JzwsC3i/Oss4LTWvIEWXXo1vZhx+7PHcsxdbnQGBBwPurHNJDSu2Pw22+2pCZiUGKexmgJksw==}
     engines: {node: '>=16.17.0'}
     hasBin: true
     peerDependencies:
       '@cloudflare/workers-types': ^4.20240620.0
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
+  wrangler@3.68.0:
+    resolution: {integrity: sha512-gsIeglkh5nOn1mHJs0bf1pOq/DvIt+umjO/5a867IYYXaN4j/ar5cRR1+F5ue3S7uEjYCLIZZjs8ESiPTSEt+Q==}
+    engines: {node: '>=16.17.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20240725.0
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -3021,6 +3071,18 @@ packages:
 
   ws@8.16.0:
     resolution: {integrity: sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.18.0:
+    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -3249,7 +3311,7 @@ snapshots:
     dependencies:
       mime: 3.0.0
 
-  '@cloudflare/vitest-pool-workers@0.4.7(@cloudflare/workers-types@4.20240729.0)(@vitest/runner@1.5.0)(@vitest/snapshot@1.5.0)(vitest@1.5.0(@types/node@20.11.19))':
+  '@cloudflare/vitest-pool-workers@0.4.17(@cloudflare/workers-types@4.20240729.0)(@vitest/runner@1.5.0)(@vitest/snapshot@1.5.0)(vitest@1.5.0(@types/node@20.11.19))':
     dependencies:
       '@vitest/runner': 1.5.0
       '@vitest/snapshot': 1.5.0
@@ -3257,10 +3319,10 @@ snapshots:
       cjs-module-lexer: 1.2.3
       devalue: 4.3.2
       esbuild: 0.17.19
-      miniflare: 3.20240620.0
+      miniflare: 3.20240725.0
       semver: 7.6.0
       vitest: 1.5.0(@types/node@20.11.19)
-      wrangler: 3.62.0(@cloudflare/workers-types@4.20240729.0)
+      wrangler: 3.68.0(@cloudflare/workers-types@4.20240729.0)
       zod: 3.22.4
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
@@ -3271,16 +3333,31 @@ snapshots:
   '@cloudflare/workerd-darwin-64@1.20240620.1':
     optional: true
 
+  '@cloudflare/workerd-darwin-64@1.20240725.0':
+    optional: true
+
   '@cloudflare/workerd-darwin-arm64@1.20240620.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20240725.0':
     optional: true
 
   '@cloudflare/workerd-linux-64@1.20240620.1':
     optional: true
 
+  '@cloudflare/workerd-linux-64@1.20240725.0':
+    optional: true
+
   '@cloudflare/workerd-linux-arm64@1.20240620.1':
     optional: true
 
+  '@cloudflare/workerd-linux-arm64@1.20240725.0':
+    optional: true
+
   '@cloudflare/workerd-windows-64@1.20240620.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20240725.0':
     optional: true
 
   '@cloudflare/workers-types@4.20240729.0': {}
@@ -5268,6 +5345,25 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  miniflare@3.20240725.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      acorn: 8.11.3
+      acorn-walk: 8.3.2
+      capnp-ts: 0.7.0
+      exit-hook: 2.2.1
+      glob-to-regexp: 0.4.1
+      stoppable: 1.1.0
+      undici: 5.28.4
+      workerd: 1.20240725.0
+      ws: 8.18.0
+      youch: 3.3.3
+      zod: 3.22.4
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.11
@@ -6231,6 +6327,14 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20240620.1
       '@cloudflare/workerd-windows-64': 1.20240620.1
 
+  workerd@1.20240725.0:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20240725.0
+      '@cloudflare/workerd-darwin-arm64': 1.20240725.0
+      '@cloudflare/workerd-linux-64': 1.20240725.0
+      '@cloudflare/workerd-linux-arm64': 1.20240725.0
+      '@cloudflare/workerd-windows-64': 1.20240725.0
+
   wrangler@3.62.0(@cloudflare/workers-types@4.20240729.0):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.3.4
@@ -6257,6 +6361,33 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  wrangler@3.68.0(@cloudflare/workers-types@4.20240729.0):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.3.4
+      '@esbuild-plugins/node-globals-polyfill': 0.2.3(esbuild@0.17.19)
+      '@esbuild-plugins/node-modules-polyfill': 0.2.2(esbuild@0.17.19)
+      blake3-wasm: 2.1.5
+      chokidar: 3.6.0
+      date-fns: 3.6.0
+      esbuild: 0.17.19
+      miniflare: 3.20240725.0
+      nanoid: 3.3.7
+      path-to-regexp: 6.2.1
+      resolve: 1.22.8
+      resolve.exports: 2.0.2
+      selfsigned: 2.4.1
+      source-map: 0.6.1
+      unenv: unenv-nightly@1.10.0-1717606461.a117952
+      workerd: 1.20240725.0
+      xxhash-wasm: 1.0.2
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20240729.0
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -6272,6 +6403,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.16.0: {}
+
+  ws@8.18.0: {}
 
   xxhash-wasm@1.0.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,10 +26,10 @@ importers:
         version: 2.27.7
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.4.7
-        version: 0.4.7(@cloudflare/workers-types@4.20240620.0)(@vitest/runner@1.5.0)(@vitest/snapshot@1.5.0)(vitest@1.5.0(@types/node@20.11.19))
+        version: 0.4.7(@cloudflare/workers-types@4.20240729.0)(@vitest/runner@1.5.0)(@vitest/snapshot@1.5.0)(vitest@1.5.0(@types/node@20.11.19))
       '@cloudflare/workers-types':
-        specifier: ^4.20240620.0
-        version: 4.20240620.0
+        specifier: ^4.20240729.0
+        version: 4.20240729.0
       '@naporin0624/eslint-config':
         specifier: ^0.14.0
         version: 0.14.0(eslint@8.56.0)(prettier@3.2.5)(typescript@5.5.2)
@@ -59,7 +59,7 @@ importers:
         version: 1.5.0(@types/node@20.11.19)
       wrangler:
         specifier: ^3.62.0
-        version: 3.62.0(@cloudflare/workers-types@4.20240620.0)
+        version: 3.62.0(@cloudflare/workers-types@4.20240729.0)
 
 packages:
 
@@ -179,8 +179,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-types@4.20240620.0':
-    resolution: {integrity: sha512-CQD8YS6evRob7LChvIX3gE3zYo0KVgaLDOu1SwNP1BVIS2Sa0b+FC8S1e1hhrNN8/E4chYlVN+FDAgA4KRDUEQ==}
+  '@cloudflare/workers-types@4.20240729.0':
+    resolution: {integrity: sha512-wfe44YQkv5T9aBr/z95P706r2/Ydg32weJYyBOhvge7FqtdY6mM7l39rybNiJrbJoyN16dd0xxyQMf23aJNC6Q==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -3249,7 +3249,7 @@ snapshots:
     dependencies:
       mime: 3.0.0
 
-  '@cloudflare/vitest-pool-workers@0.4.7(@cloudflare/workers-types@4.20240620.0)(@vitest/runner@1.5.0)(@vitest/snapshot@1.5.0)(vitest@1.5.0(@types/node@20.11.19))':
+  '@cloudflare/vitest-pool-workers@0.4.7(@cloudflare/workers-types@4.20240729.0)(@vitest/runner@1.5.0)(@vitest/snapshot@1.5.0)(vitest@1.5.0(@types/node@20.11.19))':
     dependencies:
       '@vitest/runner': 1.5.0
       '@vitest/snapshot': 1.5.0
@@ -3260,7 +3260,7 @@ snapshots:
       miniflare: 3.20240620.0
       semver: 7.6.0
       vitest: 1.5.0(@types/node@20.11.19)
-      wrangler: 3.62.0(@cloudflare/workers-types@4.20240620.0)
+      wrangler: 3.62.0(@cloudflare/workers-types@4.20240729.0)
       zod: 3.22.4
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
@@ -3283,7 +3283,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20240620.1':
     optional: true
 
-  '@cloudflare/workers-types@4.20240620.0': {}
+  '@cloudflare/workers-types@4.20240729.0': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -3597,10 +3597,10 @@ snapshots:
       '@typescript-eslint/parser': 6.21.0(eslint@8.56.0)(typescript@5.5.2)
       eslint: 8.56.0
       eslint-config-prettier: 9.1.0(eslint@8.56.0)
-      eslint-config-standard: 17.1.0(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0))(eslint-plugin-n@16.6.2(eslint@8.56.0))(eslint-plugin-promise@6.1.1(eslint@8.56.0))(eslint@8.56.0)
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-config-standard: 17.1.0(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0))(eslint-plugin-n@16.6.2(eslint@8.56.0))(eslint-plugin-promise@6.1.1(eslint@8.56.0))(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1)(eslint@8.56.0)
       eslint-plugin-deprecation: 2.0.0(eslint@8.56.0)(typescript@5.5.2)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       eslint-plugin-import-access: 2.1.2(eslint@8.56.0)(typescript@5.5.2)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-n: 16.6.2(eslint@8.56.0)
@@ -4396,10 +4396,10 @@ snapshots:
     dependencies:
       eslint: 8.56.0
 
-  eslint-config-standard@17.1.0(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0))(eslint-plugin-n@16.6.2(eslint@8.56.0))(eslint-plugin-promise@6.1.1(eslint@8.56.0))(eslint@8.56.0):
+  eslint-config-standard@17.1.0(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0))(eslint-plugin-n@16.6.2(eslint@8.56.0))(eslint-plugin-promise@6.1.1(eslint@8.56.0))(eslint@8.56.0):
     dependencies:
       eslint: 8.56.0
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       eslint-plugin-n: 16.6.2(eslint@8.56.0)
       eslint-plugin-promise: 6.1.1(eslint@8.56.0)
 
@@ -4411,13 +4411,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1)(eslint@8.56.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.56.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1)(eslint@8.56.0))(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -4428,14 +4428,14 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1)(eslint@8.56.0))(eslint@8.56.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.21.0(eslint@8.56.0)(typescript@5.5.2)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1)(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -4465,7 +4465,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.4
@@ -4475,7 +4475,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1)(eslint@8.56.0))(eslint@8.56.0)
       hasown: 2.0.1
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -6231,7 +6231,7 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20240620.1
       '@cloudflare/workerd-windows-64': 1.20240620.1
 
-  wrangler@3.62.0(@cloudflare/workers-types@4.20240620.0):
+  wrangler@3.62.0(@cloudflare/workers-types@4.20240729.0):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.3.4
       '@esbuild-plugins/node-globals-polyfill': 0.2.3(esbuild@0.17.19)
@@ -6250,7 +6250,7 @@ snapshots:
       unenv: unenv-nightly@1.10.0-1717606461.a117952
       xxhash-wasm: 1.0.2
     optionalDependencies:
-      '@cloudflare/workers-types': 4.20240620.0
+      '@cloudflare/workers-types': 4.20240729.0
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil

--- a/src/e2e/e2e.test.ts
+++ b/src/e2e/e2e.test.ts
@@ -1,0 +1,90 @@
+import { SELF, env, runInDurableObject } from "cloudflare:test";
+import { hc } from "hono/client";
+import { fromUint8Array } from "js-base64";
+
+import { createSyncMessage, createYDocMessage } from "./helper";
+
+import type { AppType } from ".";
+import type { InternalYDurableObject } from "../yjs/internal";
+
+describe("yRoute Shorthand", () => {
+  it("should return a route", async () => {
+    const res = await SELF.fetch("http://localhost/shorthand/1", {
+      headers: {
+        Upgrade: "websocket",
+      },
+    });
+    expect(res.status).toBe(101);
+    expect(res.webSocket).toBeInstanceOf(WebSocket);
+  });
+
+  it("has no header", async () => {
+    const res = await SELF.fetch("http://localhost/shorthand/1");
+    expect(res.status).toBe(426);
+    await expect(res.text()).resolves.toBe("Expected websocket");
+  });
+
+  it("check typing", () => {
+    const client = hc<AppType>("http://localhost", {
+      fetch: SELF.fetch.bind(SELF),
+    });
+
+    expectTypeOf(client.shorthand[":id"].$ws).toEqualTypeOf<
+      (args?: { param: { id: string } } | undefined) => WebSocket
+    >();
+  });
+});
+
+describe("endpoint request", () => {
+  it("should return a response", async () => {
+    const res = await SELF.fetch("http://localhost/rooms/1", {
+      headers: { Upgrade: "websocket" },
+    });
+    expect(res.status).toBe(101);
+    expect(res.webSocket).toBeInstanceOf(WebSocket);
+  });
+
+  it("has no header", async () => {
+    const res = await SELF.fetch("http://localhost/rooms/1");
+    expect(res.status).toBe(426);
+    await expect(res.text()).resolves.toBe("Expected websocket");
+  });
+
+  it("get YDoc", async () => {
+    const roomId = "1";
+    const id = env.Y_DURABLE_OBJECTS.idFromName(roomId);
+    const stub = env.Y_DURABLE_OBJECTS.get(id);
+    const message = createYDocMessage("get state");
+    const update = createSyncMessage(message);
+
+    await runInDurableObject(stub, async (instance: InternalYDurableObject) => {
+      await instance.updateYDoc(update);
+    });
+
+    const res = await SELF.fetch(`http://localhost/rooms/${roomId}/state`);
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ doc: fromUint8Array(message) });
+  });
+
+  it("update YDoc", async () => {
+    const message = createYDocMessage("get state");
+    const update = createSyncMessage(message);
+
+    const roomId = "1";
+    const id = env.Y_DURABLE_OBJECTS.idFromName(roomId);
+    const stub = env.Y_DURABLE_OBJECTS.get(id);
+
+    const res = await SELF.fetch(`http://localhost/rooms/${roomId}/update`, {
+      method: "POST",
+      body: update.buffer,
+    });
+    expect(res.status).toBe(200);
+
+    await runInDurableObject(stub, async (instance: InternalYDurableObject) => {
+      const state = await instance.getYDoc();
+      expect(state).toEqual(message);
+    });
+  });
+});

--- a/src/e2e/e2e.test.ts
+++ b/src/e2e/e2e.test.ts
@@ -18,13 +18,13 @@ describe("yRoute Shorthand", () => {
     expect(res.webSocket).toBeInstanceOf(WebSocket);
   });
 
-  it("has no header", async () => {
+  it("should return status 426 if no headers are present", async () => {
     const res = await SELF.fetch("http://localhost/shorthand/1");
     expect(res.status).toBe(426);
     await expect(res.text()).resolves.toBe("Expected websocket");
   });
 
-  it("check typing", () => {
+  it("should verify the typing of the shorthand route", () => {
     const client = hc<AppType>("http://localhost", {
       fetch: SELF.fetch.bind(SELF),
     });
@@ -36,7 +36,7 @@ describe("yRoute Shorthand", () => {
 });
 
 describe("endpoint request", () => {
-  it("should return a response", async () => {
+  it("should return a WebSocket response", async () => {
     const res = await SELF.fetch("http://localhost/rooms/1", {
       headers: { Upgrade: "websocket" },
     });
@@ -44,13 +44,13 @@ describe("endpoint request", () => {
     expect(res.webSocket).toBeInstanceOf(WebSocket);
   });
 
-  it("has no header", async () => {
+  it("should return status 426 if no headers are present", async () => {
     const res = await SELF.fetch("http://localhost/rooms/1");
     expect(res.status).toBe(426);
     await expect(res.text()).resolves.toBe("Expected websocket");
   });
 
-  it("get YDoc", async () => {
+  it("should get the YDoc state", async () => {
     const roomId = "1";
     const id = env.Y_DURABLE_OBJECTS.idFromName(roomId);
     const stub = env.Y_DURABLE_OBJECTS.get(id);
@@ -68,7 +68,7 @@ describe("endpoint request", () => {
     expect(json).toEqual({ doc: fromUint8Array(message) });
   });
 
-  it("update YDoc", async () => {
+  it("should update the YDoc state", async () => {
     const message = createYDocMessage("get state");
     const update = createSyncMessage(message);
 

--- a/src/e2e/helper.ts
+++ b/src/e2e/helper.ts
@@ -1,0 +1,22 @@
+import { createEncoder, toUint8Array, writeVarUint } from "lib0/encoding.js";
+import { writeUpdate } from "y-protocols/sync.js";
+import { Doc, encodeStateAsUpdate } from "yjs";
+
+import { messageType } from "../yjs/message-type";
+
+// Helper to create updates based on document type
+export const createYDocMessage = (content: string = "Hello World!") => {
+  const doc = new Doc();
+  doc.getText("root").insert(0, content);
+
+  return encodeStateAsUpdate(doc);
+};
+
+// Helper to create an encoded message from an update
+export const createSyncMessage = (update: Uint8Array) => {
+  const encoder = createEncoder();
+  writeVarUint(encoder, messageType.sync);
+  writeUpdate(encoder, update);
+
+  return toUint8Array(encoder);
+};

--- a/src/e2e/index.ts
+++ b/src/e2e/index.ts
@@ -1,0 +1,68 @@
+import { Hono } from "hono";
+import { hc } from "hono/client";
+import { fromUint8Array } from "js-base64";
+
+import { yRoute } from "..";
+import { upgrade } from "../middleware";
+import { YDurableObjects } from "../yjs";
+
+import type { CloudflareEnv } from "./types";
+import type { YDurableObjectsAppType } from "../yjs";
+
+type Env = {
+  Bindings: { [K in keyof CloudflareEnv]: CloudflareEnv[K] };
+};
+
+const app = new Hono<Env>();
+
+const route = app
+  .route(
+    "/shorthand",
+    yRoute<Env>((env) => env.Y_DURABLE_OBJECTS),
+  )
+  .get("/rooms/:id", upgrade(), async (c) => {
+    const roomId = c.req.param("id");
+    const id = c.env.Y_DURABLE_OBJECTS.idFromName(roomId);
+    const stub = c.env.Y_DURABLE_OBJECTS.get(id);
+
+    const url = new URL("/", c.req.url);
+    const client = hc<YDurableObjectsAppType>(url.toString(), {
+      fetch: stub.fetch.bind(stub),
+    });
+    const res = await client.rooms[":roomId"].$get(
+      { param: { roomId } },
+      { init: { headers: c.req.raw.headers } },
+    );
+
+    return new Response(null, {
+      webSocket: res.webSocket,
+      status: res.status,
+      statusText: res.statusText,
+    });
+  })
+  .get("/rooms/:id/state", async (c) => {
+    const roomId = c.req.param("id");
+    const id = c.env.Y_DURABLE_OBJECTS.idFromName(roomId);
+    const stub = c.env.Y_DURABLE_OBJECTS.get(id);
+
+    const doc = await stub.getYDoc();
+    const base64 = fromUint8Array(doc);
+
+    return c.json({ doc: base64 }, 200);
+  })
+  .post("/rooms/:id/update", async (c) => {
+    const roomId = c.req.param("id");
+    const id = c.env.Y_DURABLE_OBJECTS.idFromName(roomId);
+    const stub = c.env.Y_DURABLE_OBJECTS.get(id);
+
+    const buffer = await c.req.arrayBuffer();
+    const update = new Uint8Array(buffer);
+
+    await stub.updateYDoc(update);
+
+    return c.json(null, 200);
+  });
+
+export default app;
+export type AppType = typeof route;
+export { YDurableObjects };

--- a/src/e2e/types.d.ts
+++ b/src/e2e/types.d.ts
@@ -1,9 +1,11 @@
 /* eslint-disable import/no-unresolved */
 import "cloudflare:test";
-import { InternalYDurableObject } from "../yjs/internal";
+import { YDurableObjects } from "../yjs";
+
+interface CloudflareEnv {
+  Y_DURABLE_OBJECTS: DurableObjectNamespace<YDurableObjects>;
+}
 
 declare module "cloudflare:test" {
-  interface ProvidedEnv {
-    Y_DURABLE_OBJECTS: DurableObjectNamespace<InternalYDurableObject>;
-  }
+  interface ProvidedEnv extends CloudflareEnv {}
 }

--- a/src/e2e/types.d.ts
+++ b/src/e2e/types.d.ts
@@ -1,0 +1,9 @@
+/* eslint-disable import/no-unresolved */
+import "cloudflare:test";
+import { InternalYDurableObject } from "../yjs/internal";
+
+declare module "cloudflare:test" {
+  interface ProvidedEnv {
+    Y_DURABLE_OBJECTS: DurableObjectNamespace<InternalYDurableObject>;
+  }
+}

--- a/src/e2e/y-durableobjects.test.ts
+++ b/src/e2e/y-durableobjects.test.ts
@@ -1,0 +1,136 @@
+import { env, runInDurableObject } from "cloudflare:test";
+import { hc } from "hono/client";
+import { createEncoder, writeVarUint, toUint8Array } from "lib0/encoding.js";
+import { expect, describe, it } from "vitest";
+import { writeUpdate } from "y-protocols/sync.js";
+import { Doc, encodeStateAsUpdate } from "yjs";
+
+import { YDurableObjects } from "../yjs";
+import { messageType } from "../yjs/message-type";
+
+import type { YDurableObjectsAppType } from "../yjs";
+import type { InternalYDurableObject } from "../yjs/internal";
+
+// Helper to create updates based on document type
+const createYDocMessage = (content: string = "Hello World!") => {
+  const doc = new Doc();
+  doc.getText("root").insert(0, content);
+
+  return encodeStateAsUpdate(doc);
+};
+
+// Helper to create an encoded message from an update
+const createSyncMessage = (update: Uint8Array) => {
+  const encoder = createEncoder();
+  writeVarUint(encoder, messageType.sync);
+  writeUpdate(encoder, update);
+
+  return toUint8Array(encoder);
+};
+
+describe("YDurableObjects", () => {
+  it("initializes correctly", async () => {
+    const id = env.Y_DURABLE_OBJECTS.newUniqueId();
+    const stub = env.Y_DURABLE_OBJECTS.get(id);
+
+    await runInDurableObject(stub, async (instance: InternalYDurableObject) => {
+      expect(instance).toBeInstanceOf(YDurableObjects);
+      expect(instance.doc).toBeDefined();
+      expect(instance.storage).toBeDefined();
+    });
+  });
+
+  it("create a room from request", async () => {
+    const id = env.Y_DURABLE_OBJECTS.newUniqueId();
+    const stub = env.Y_DURABLE_OBJECTS.get(id);
+
+    await runInDurableObject(stub, async (instance: InternalYDurableObject) => {
+      const client = hc<YDurableObjectsAppType>("http://localhost", {
+        fetch(req: RequestInfo | URL) {
+          const r = new Request(req);
+
+          return instance.fetch?.(r) ?? new Response(null);
+        },
+      });
+      const res = await client.rooms[":roomId"].$get({
+        param: { roomId: "room1" },
+      });
+
+      expect(res.webSocket).toBeInstanceOf(WebSocket);
+    });
+  });
+
+  it("creates a room correctly", async () => {
+    const id = env.Y_DURABLE_OBJECTS.newUniqueId();
+    const stub = env.Y_DURABLE_OBJECTS.get(id);
+
+    await runInDurableObject(stub, async (instance: InternalYDurableObject) => {
+      const roomId = "room1";
+      const client = await instance.createRoom(roomId);
+
+      expect(client).toBeInstanceOf(WebSocket);
+      expect(instance.sessions.size).toBe(1);
+    });
+  });
+
+  it("updates YDoc correctly", async () => {
+    const id = env.Y_DURABLE_OBJECTS.newUniqueId();
+    const stub = env.Y_DURABLE_OBJECTS.get(id);
+
+    await runInDurableObject(stub, async (instance: InternalYDurableObject) => {
+      const message = createYDocMessage();
+      const update = createSyncMessage(message);
+      await instance.updateYDoc(update);
+
+      const docState = instance.getYDoc();
+      expect(docState).toEqual(message);
+    });
+  });
+
+  it("handles WebSocket messages correctly", async () => {
+    const id = env.Y_DURABLE_OBJECTS.newUniqueId();
+    const stub = env.Y_DURABLE_OBJECTS.get(id);
+
+    await runInDurableObject(stub, async (instance: InternalYDurableObject) => {
+      const roomId = "room1";
+      const client = await instance.createRoom(roomId);
+
+      const message = createYDocMessage();
+      const update = createSyncMessage(message);
+      await instance.webSocketMessage?.(client, update.buffer);
+
+      const docState = await instance.getYDoc();
+      expect(docState).toEqual(message);
+    });
+  });
+
+  it("handles WebSocket errors correctly", async () => {
+    const id = env.Y_DURABLE_OBJECTS.newUniqueId();
+    const stub = env.Y_DURABLE_OBJECTS.get(id);
+
+    await runInDurableObject(stub, async (instance: InternalYDurableObject) => {
+      const roomId = "room1";
+      await instance.createRoom(roomId);
+      const [server] = Array.from(instance.sessions.entries()).at(0)!;
+
+      await instance.webSocketError?.(server, {});
+
+      expect(instance.sessions.size).toBe(0);
+    });
+  });
+
+  it("handles WebSocket close correctly", async () => {
+    const id = env.Y_DURABLE_OBJECTS.newUniqueId();
+    const stub = env.Y_DURABLE_OBJECTS.get(id);
+
+    await runInDurableObject(stub, async (instance: InternalYDurableObject) => {
+      const roomId = "room1";
+      await instance.createRoom(roomId);
+      const [server] = Array.from(instance.sessions.entries()).at(0)!;
+
+      await instance.webSocketClose?.(server, 1001, "reason", true);
+
+      expect(instance.sessions.size).toBe(0);
+    });
+  });
+});

--- a/src/e2e/y-durableobjects.test.ts
+++ b/src/e2e/y-durableobjects.test.ts
@@ -82,7 +82,7 @@ describe("YDurableObjects", () => {
       const update = createSyncMessage(message);
       await instance.updateYDoc(update);
 
-      const docState = instance.getYDoc();
+      const docState = await instance.getYDoc();
       expect(docState).toEqual(message);
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,12 +21,8 @@ export const yRoute = <E extends Env>(selector: Selector<E>) => {
       fetch: stub.fetch.bind(stub),
     });
     const res = await client.rooms[":roomId"].$get(
-      {
-        param: { roomId: c.req.param("id") },
-      },
-      {
-        init: { headers: c.req.raw.headers },
-      },
+      { param: { roomId: c.req.param("id") } },
+      { init: { headers: c.req.raw.headers } },
     );
 
     return new Response(null, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 import { Hono } from "hono";
+import { hc } from "hono/client";
 
 import { upgrade } from "./middleware";
 
+import type { YDurableObjectsAppType } from "./yjs";
 import type { Env } from "hono";
-
-export { YDurableObjects } from "./yjs";
 
 const app = new Hono();
 
@@ -13,14 +13,21 @@ type Selector<E extends Env> = (c: E["Bindings"]) => DurableObjectNamespace;
 export const yRoute = <E extends Env>(selector: Selector<E>) => {
   const route = app.get("/:id", upgrade(), async (c) => {
     const obj = selector(c.env as E["Bindings"]);
-    const stab = obj.get(obj.idFromName(c.req.param("id")));
+    const stub = obj.get(obj.idFromName(c.req.param("id")));
 
     // get websocket connection
     const url = new URL("/", c.req.url);
-    const res = await stab.fetch(url.href, {
-      headers: c.req.raw.headers,
+    const client = hc<YDurableObjectsAppType>(url.toString(), {
+      fetch: stub.fetch.bind(stub),
     });
-    if (res.webSocket === null) return c.body(null, 500);
+    const res = await client.rooms[":roomId"].$get(
+      {
+        param: { roomId: c.req.param("id") },
+      },
+      {
+        init: { headers: c.req.raw.headers },
+      },
+    );
 
     return new Response(null, {
       webSocket: res.webSocket,
@@ -31,6 +38,8 @@ export const yRoute = <E extends Env>(selector: Selector<E>) => {
 
   return route;
 };
+
+export { YDurableObjects, type YDurableObjectsAppType } from "./yjs";
 export type YRoute = ReturnType<typeof yRoute>;
 export type { YTransactionStorage } from "./yjs/storage";
 export { type RemoteDoc, WSSharedDoc } from "./yjs/remote";

--- a/src/middleware/upgrade.test.ts
+++ b/src/middleware/upgrade.test.ts
@@ -1,0 +1,30 @@
+import { Hono } from "hono";
+
+import { upgrade } from ".";
+
+describe("Upgrade Middleware", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    app = new Hono();
+    app.get("/", upgrade(), (c) => c.text("WebSocket connection established"));
+  });
+
+  it("returns status 426 when Upgrade header is not websocket", async () => {
+    const req = new Request("http://localhost/", {
+      headers: { Upgrade: "non-websocket" },
+    });
+    const res = await app.request(req);
+    expect(res.status).toBe(426);
+    expect(await res.text()).toBe("Expected websocket");
+  });
+
+  it("passes to the next middleware when Upgrade header is websocket", async () => {
+    const req = new Request("http://localhost/", {
+      headers: { Upgrade: "websocket" },
+    });
+    const res = await app.request(req);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("WebSocket connection established");
+  });
+});

--- a/src/yjs/hono/create-app.test.ts
+++ b/src/yjs/hono/create-app.test.ts
@@ -1,0 +1,51 @@
+import { Hono } from "hono";
+
+import { createApp } from ".";
+
+type Service = {
+  createRoom(roomId: string): Promise<WebSocket> | WebSocket;
+};
+
+describe("Room Creation API", () => {
+  let app: Hono;
+  let service: Service;
+
+  beforeEach(() => {
+    service = {
+      createRoom: vi.fn(),
+    };
+    app = createApp(service);
+  });
+
+  it("should initialize correctly", () => {
+    expect(app).toBeInstanceOf(Hono);
+  });
+
+  it("should create a room and establish a WebSocket connection", async () => {
+    const mockWebSocket = new WebSocket("ws://example.com");
+    service.createRoom = vi.fn().mockResolvedValue(mockWebSocket);
+
+    const response = await app.request("http://localhost/rooms/testRoom", {
+      headers: {
+        Upgrade: "websocket",
+      },
+    });
+
+    expect(response.status).toBe(101);
+    expect(response.webSocket).toBe(mockWebSocket);
+    expect(service.createRoom).toHaveBeenCalledWith("testRoom");
+  });
+
+  it("should handle createRoom error correctly", async () => {
+    service.createRoom = vi.fn().mockRejectedValue(new Error("Service Error"));
+
+    const response = await app.request("http://localhost/rooms/testRoom", {
+      headers: {
+        Upgrade: "websocket",
+      },
+    });
+
+    expect(response.status).toBe(500);
+    expect(service.createRoom).toHaveBeenCalledWith("testRoom");
+  });
+});

--- a/src/yjs/hono/index.ts
+++ b/src/yjs/hono/index.ts
@@ -1,0 +1,20 @@
+import { Hono } from "hono";
+
+type Service = {
+  createRoom(roomId: string): Promise<WebSocket> | WebSocket;
+};
+
+export const createApp = (service: Service) => {
+  const app = new Hono();
+
+  return app.get("/rooms/:roomId", async (c) => {
+    const roomId = c.req.param("roomId");
+    const client = await service.createRoom(roomId);
+
+    return new Response(null, {
+      webSocket: client,
+      status: 101,
+      statusText: "Switching Protocols",
+    });
+  });
+};

--- a/src/yjs/index.ts
+++ b/src/yjs/index.ts
@@ -138,7 +138,7 @@ export class YDurableObjects<T extends Env> extends DurableObject<
     }
   }
 
-  private async cleanup() {
+  protected async cleanup() {
     if (this.sessions.size < 1) {
       await this.storage.commit();
     }

--- a/src/yjs/internal.ts
+++ b/src/yjs/internal.ts
@@ -1,19 +1,28 @@
 import type { WSSharedDoc } from "./remote";
 import type { YTransactionStorageImpl } from "./storage";
-import type { DurableObject } from "cloudflare:workers";
 
-export interface InternalYDurableObject extends DurableObject {
+export interface InternalYDurableObject {
+  // private state
   doc: WSSharedDoc;
   storage: YTransactionStorageImpl;
   sessions: Map<WebSocket, () => void>;
   awarenessClients: Set<number>;
 
+  // private api
+
   onStart(): Promise<void>;
   createRoom(roomId: string): WebSocket;
-  getYDoc(): Promise<Uint8Array>;
-  updateYDoc(update: Uint8Array): Promise<void>;
 
   registerWebSocket(ws: WebSocket): void;
   unregisterWebSocket(ws: WebSocket): void;
   cleanup(): void;
+
+  // public api
+  fetch(request: Request): Promise<Response>;
+  webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): void;
+  webSocketError(ws: WebSocket): void;
+  webSocketClose(ws: WebSocket): void;
+
+  getYDoc(): Promise<Uint8Array>;
+  updateYDoc(update: Uint8Array): Promise<void>;
 }

--- a/src/yjs/internal.ts
+++ b/src/yjs/internal.ts
@@ -1,0 +1,19 @@
+import type { WSSharedDoc } from "./remote";
+import type { YTransactionStorageImpl } from "./storage";
+import type { DurableObject } from "cloudflare:workers";
+
+export interface InternalYDurableObject extends DurableObject {
+  doc: WSSharedDoc;
+  storage: YTransactionStorageImpl;
+  sessions: Map<WebSocket, () => void>;
+  awarenessClients: Set<number>;
+
+  onStart(): Promise<void>;
+  createRoom(roomId: string): WebSocket;
+  getYDoc(): Promise<Uint8Array>;
+  updateYDoc(update: Uint8Array): Promise<void>;
+
+  registerWebSocket(ws: WebSocket): void;
+  unregisterWebSocket(ws: WebSocket): void;
+  cleanup(): void;
+}

--- a/src/yjs/remote/ws-shared-doc.test.ts
+++ b/src/yjs/remote/ws-shared-doc.test.ts
@@ -11,7 +11,7 @@ import { WSSharedDoc } from "./ws-shared-doc";
 import type { Mock } from "vitest";
 
 // Helper to create updates based on document type
-const messageUpdate = (content: string = "Hello World!") => {
+const createYDocMessage = (content: string = "Hello World!") => {
   const doc = new Doc();
   doc.getText("root").insert(0, content);
 
@@ -53,7 +53,7 @@ describe("WSSharedDoc", () => {
 
   describe("Handling Yjs Updates", () => {
     it("should process Yjs updates and notify listeners", () => {
-      const update = messageUpdate("Hello, world!");
+      const update = createYDocMessage("Hello, world!");
       const message = createSyncMessage(update);
 
       doc.update(message);
@@ -70,8 +70,8 @@ describe("WSSharedDoc", () => {
     it("should add and remove listeners correctly", () => {
       const anotherListener = vi.fn();
       const unsubscribe = doc.notify(anotherListener);
-      const message1 = createSyncMessage(messageUpdate("text1"));
-      const message2 = createSyncMessage(messageUpdate("text2"));
+      const message1 = createSyncMessage(createYDocMessage("text1"));
+      const message2 = createSyncMessage(createYDocMessage("text2"));
 
       doc.update(message1);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,11 @@
     "esModuleInterop": true,
     "strict": true,
     "lib": ["esnext"],
-    "types": ["@cloudflare/workers-types", "vitest/globals"],
+    "types": [
+      "@cloudflare/workers-types",
+      "vitest/globals",
+      "@cloudflare/vitest-pool-workers"
+    ],
     "noEmit": true,
     "skipLibCheck": true
   },

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   entry: {
     index: "src/index.ts",
-    "helpers/upgrade": "src/middleware/upgrade/index.ts",
+    "helpers/upgrade": "src/middleware/index.ts",
   },
   sourcemap: true,
   dts: {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -9,5 +9,5 @@ export default defineConfig({
   splitting: true,
   clean: true,
   format: ["cjs", "esm"],
-  external: ["hono"],
+  external: ["hono", /cloudflare:/],
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: {
+    index: "src/index.ts",
+    "helpers/upgrade": "src/middleware/upgrade/index.ts",
+  },
   sourcemap: true,
   dts: {
     banner: '/// <reference types="@cloudflare/workers-types" />',

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,5 @@
 name = "yjs-workers"
+main = "src/index.ts"
 compatibility_date = "2024-04-05"
 compatibility_flags=["nodejs_compat"]
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,5 @@
 name = "yjs-workers"
-main = "src/index.ts"
+main = "src/e2e/index.ts"
 compatibility_date = "2024-04-05"
 compatibility_flags=["nodejs_compat"]
 


### PR DESCRIPTION
closed: #49
closed: #46  

This PR introduces several significant updates to the `y-durableobjects` library, with a major focus on adding new JS RPC support for `getYDoc` and `updateYDoc` APIs. These enhancements significantly improve the library's functionality and ease of integration with Hono. Key changes include:

1. **Major Features**:
    - **JS RPC APIs `getYDoc` and `updateYDoc`**:
        - Implemented new JS RPC APIs to fetch (`getYDoc`) and update (`updateYDoc`) YDocs within Durable Objects.
        - Allows manipulating YDocs from sources other than WebSocket, enhancing flexibility and control.

2. **Hono Integration**:
    - Added examples for integrating `y-durableobjects` with Hono, using both shorthand and detailed methods.
    - Demonstrated how to handle WebSocket connections via fetch due to the current limitations of JS RPC (see [Cloudflare issue](https://github.com/cloudflare/workerd/issues/2319)).

3. **Extending with JS RPC**:
    - Explained how to extend `y-durableobjects` for advanced operations, including accessing and manipulating protected fields:
        - `app`: The Hono app instance used to handle requests.
        - `doc`: An instance of `WSSharedDoc` managing the YDoc state.
        - `storage`: A `YTransactionStorageImpl` instance for storing and retrieving YDoc updates.
        - `sessions`: A map to manage active WebSocket sessions.
        - `awarenessClients`: A set to track client awareness states.
    - Provided a minimal example of creating a custom Durable Object by extending `YDurableObjects`.

4. **Client-side Typed Fetch with Hono RPC**:
    - Included a guide for creating a typed client using `hc` from `hono/client` to facilitate Hono RPC on the client side.

5. **Documentation Updates**:
    - Updated the README with detailed examples and explanations for the new features and integrations.
    - Ensured clarity and ease of understanding for developers looking to utilize the new functionalities.

These enhancements aim to provide developers with more robust tools and clearer guidance for integrating Yjs and Durable Objects within the Cloudflare Workers environment, leveraging the power of Hono for efficient and scalable real-time collaboration solutions.